### PR TITLE
Add error styles for `linter` and `spell-check`

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -190,7 +190,7 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 }
 atom-text-editor.editor .linter-highlight, .linter-highlight {
 	&.error .region {
-		.highlight-underline(@background-color-error, transparent);
+		.highlight-underline(@background-color-error; transparent);
 	}
 	&.warning .region {
 		.highlight-underline(@background-color-warning);
@@ -200,7 +200,7 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
 	}
 }
 .syntax--invalid.syntax--illegal, .spell-check-misspelling .region {
-	.highlight-underline(@background-color-error, transparent);
+	.highlight-underline(@background-color-error; transparent);
 }
 
 .syntax--string {

--- a/styles/base.less
+++ b/styles/base.less
@@ -174,7 +174,7 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 @keyframes pulseError {
 	0%,100% {
 		box-shadow: inset 0 -1px 0 @background-color-error,
-      0 7px 14px fade(@background-color-error, 10%);
+			0 7px 14px fade(@background-color-error, 10%);
 	}
 	50% {
 		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
@@ -183,7 +183,7 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 @keyframes pulseWarning {
 	0%,100% {
 		box-shadow: inset 0 -1px 0 @background-color-warning,
-      0 7px 14px fade(@background-color-warning, 10%);
+			0 7px 14px fade(@background-color-warning, 10%);
 	}
 	50% {
 		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
@@ -192,25 +192,25 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 @keyframes pulseInfo {
 	0%,100% {
 		box-shadow: inset 0 -1px 0 @background-color-info,
-      0 7px 14px fade(@background-color-info, 10%);
+			0 7px 14px fade(@background-color-info, 10%);
 	}
 	50% {
 		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
 	}
 }
 atom-text-editor.editor .linter-highlight, .linter-highlight {
-  &.error .region {
-    border-bottom: none;
-    animation: pulseError 2s ease infinite;
-  }
-  &.warning .region {
-    border-bottom: none;
-    animation: pulseWarning 2s ease infinite;
-  }
-  &.trace .region, &.info .region {
-    border-bottom: none;
-    animation: pulseInfo 2s ease infinite;
-  }
+	&.error .region {
+		border-bottom: none;
+		animation: pulseError 2s ease infinite;
+	}
+	&.warning .region {
+		border-bottom: none;
+		animation: pulseWarning 2s ease infinite;
+	}
+	&.trace .region, &.info .region {
+		border-bottom: none;
+		animation: pulseInfo 2s ease infinite;
+	}
 }
 .syntax--invalid.syntax--illegal, .spell-check-misspelling .region {
 	border-bottom: none;

--- a/styles/base.less
+++ b/styles/base.less
@@ -171,34 +171,36 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 	}
 }
 
-@keyframes pulseError {
-	0%,100% {
-		box-shadow: inset 0 -1px 0 @background-color-error,
-			0 7px 14px fade(@background-color-error, 10%);
-	}
-	50% {
-		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
+.highlight-underline(@color) {
+	border-bottom: none;
+	box-shadow: inset 0 -1px 0 @color, 0 7px 14px fade(@color, 10%);
+}
+.highlight-underline(@color1; @color2) {
+	@name: replace("pulse-underline-@{color1}", "#", "");
+
+	animation: ~"@{name}" 2s ease infinite;
+	@keyframes ~"@{name}" {
+		0%, 100% {
+			.highlight-underline(@color1);
+		}
+		50% {
+			.highlight-underline(@color2);
+		}
 	}
 }
 atom-text-editor.editor .linter-highlight, .linter-highlight {
 	&.error .region {
-		border-bottom: none;
-		animation: pulseError 2s ease infinite;
+		.highlight-underline(@background-color-error, transparent);
 	}
 	&.warning .region {
-		border-bottom: none;
-		box-shadow: inset 0 -1px 0 @background-color-warning,
-			0 7px 14px fade(@background-color-warning, 10%);
+		.highlight-underline(@background-color-warning);
 	}
 	&.trace .region, &.info .region {
-		border-bottom: none;
-		box-shadow: inset 0 -1px 0 @background-color-info,
-			0 7px 14px fade(@background-color-info, 10%);
+		.highlight-underline(@background-color-info);
 	}
 }
 .syntax--invalid.syntax--illegal, .spell-check-misspelling .region {
-	border-bottom: none;
-	animation: pulseError 2s ease infinite;
+	.highlight-underline(@background-color-error, transparent);
 }
 
 .syntax--string {

--- a/styles/base.less
+++ b/styles/base.less
@@ -170,17 +170,51 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 		color: @light-orange;
 	}
 }
-@keyframes pulse {
+
+@keyframes pulseError {
 	0%,100% {
-		box-shadow: inset 0 -1px 0 red, 0 7px 14px fade(red, 10%);
+		box-shadow: inset 0 -1px 0 @background-color-error,
+      0 7px 14px fade(@background-color-error, 10%);
 	}
 	50% {
 		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
 	}
 }
-.syntax--invalid.syntax--illegal {
-	box-shadow: inset 0 -1px 0 red, 0 7px 14px fade(red, 10%);
-	animation: pulse 2s ease infinite;
+@keyframes pulseWarning {
+	0%,100% {
+		box-shadow: inset 0 -1px 0 @background-color-warning,
+      0 7px 14px fade(@background-color-warning, 10%);
+	}
+	50% {
+		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
+	}
+}
+@keyframes pulseInfo {
+	0%,100% {
+		box-shadow: inset 0 -1px 0 @background-color-info,
+      0 7px 14px fade(@background-color-info, 10%);
+	}
+	50% {
+		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
+	}
+}
+atom-text-editor.editor .linter-highlight, .linter-highlight {
+  &.error .region {
+    border-bottom: none;
+    animation: pulseError 2s ease infinite;
+  }
+  &.warning .region {
+    border-bottom: none;
+    animation: pulseWarning 2s ease infinite;
+  }
+  &.trace .region, &.info .region {
+    border-bottom: none;
+    animation: pulseInfo 2s ease infinite;
+  }
+}
+.syntax--invalid.syntax--illegal, .spell-check-misspelling .region {
+	border-bottom: none;
+	animation: pulseError 2s ease infinite;
 }
 
 .syntax--string {

--- a/styles/base.less
+++ b/styles/base.less
@@ -180,24 +180,6 @@ atom-workspace[theme-nebula-ui-focusmode=enabled] {
 		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
 	}
 }
-@keyframes pulseWarning {
-	0%,100% {
-		box-shadow: inset 0 -1px 0 @background-color-warning,
-			0 7px 14px fade(@background-color-warning, 10%);
-	}
-	50% {
-		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
-	}
-}
-@keyframes pulseInfo {
-	0%,100% {
-		box-shadow: inset 0 -1px 0 @background-color-info,
-			0 7px 14px fade(@background-color-info, 10%);
-	}
-	50% {
-		box-shadow: inset 0 -1px 0 transparent, 0 7px 14px transparent;
-	}
-}
 atom-text-editor.editor .linter-highlight, .linter-highlight {
 	&.error .region {
 		border-bottom: none;
@@ -205,11 +187,13 @@ atom-text-editor.editor .linter-highlight, .linter-highlight {
 	}
 	&.warning .region {
 		border-bottom: none;
-		animation: pulseWarning 2s ease infinite;
+		box-shadow: inset 0 -1px 0 @background-color-warning,
+			0 7px 14px fade(@background-color-warning, 10%);
 	}
 	&.trace .region, &.info .region {
 		border-bottom: none;
-		animation: pulseInfo 2s ease infinite;
+		box-shadow: inset 0 -1px 0 @background-color-info,
+			0 7px 14px fade(@background-color-info, 10%);
 	}
 }
 .syntax--invalid.syntax--illegal, .spell-check-misspelling .region {


### PR DESCRIPTION
Changes the styles for Atom's `linter` and `spell-check` packages to
match Nebula's existing error styles.

Fixes tjkohli/nebula-ui#6